### PR TITLE
feat: add shanghai fork timestamp to mapper

### DIFF
--- a/clients/reth/mapper.jq
+++ b/clients/reth/mapper.jq
@@ -51,5 +51,6 @@ def to_bool:
     "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
     "londonBlock": env.HIVE_FORK_LONDON|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
+    "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
   }|remove_empty
 }


### PR DESCRIPTION
Adds the shanghai fork timestamp to the config mapper, activating shanghai for tests that specify a timestamp