### PR TITLE
use patched chain files for rpc-compat

### DIFF
--- a/simulators/ethereum/rpc-compat/Dockerfile
+++ b/simulators/ethereum/rpc-compat/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1-alpine as builder
 RUN apk add --update git ca-certificates gcc musl-dev linux-headers
 
 # Clone the tests repo.
-RUN git clone --depth 1 https://github.com/ethereum/execution-apis.git /execution-apis
+RUN git clone --depth 1 https://github.com/paradigmxyz/execution-apis.git /execution-apis
 
 # To run local tests, copy the directory into the same as the simulator and
 # uncomment the line below


### PR DESCRIPTION
Uses the modified `chain.rlp` and `*.io` files from https://github.com/paradigmxyz/execution-apis in `rpc-compat`