### PR TITLE
add shanghai timestamp to rpc-compat tests

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -133,6 +133,12 @@ set -ex
 FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.api=admin,debug,eth,net"
 #FLAGS="$FLAGS --ws"
 
+# Enable continuous sync if mining is disabled
+# TODO
+# if [ "$HIVE_MINER" == "" ]; then
+#     FLAGS="$FLAGS --debug.continuous"
+# fi
+
 if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
     JWT_SECRET="7365637265747365637265747365637265747365637265747365637265747365"
     echo -n $JWT_SECRET > /jwt.secret

--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -34,6 +34,7 @@ var (
 		"HIVE_FORK_ISTANBUL":       "0",
 		"HIVE_FORK_BERLIN":         "0",
 		"HIVE_FORK_LONDON":         "0",
+		"HIVE_SHANGHAI_TIMESTAMP":  "0",
 	}
 	files = map[string]string{
 		"genesis.json": "./tests/genesis.json",


### PR DESCRIPTION
Shanghai is expected to be enabled because the `chain.rlp` is generated with withdrawals. Without this env var, the timestamp is overwritten by `mapper.jq` in the genesis, and the chain fails to import.