### PR TITLE
feat: ignore error difference when comparing rpc output

### DIFF
--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -138,11 +138,17 @@ func runTest(t *hivesim.T, c *hivesim.Client, data []byte) error {
 				return fmt.Errorf("failed to unmarshal value: %s\n", err)
 			}
 
-			// If errors exist in both, make them equal.
-			// While error comparison might be desirable, error text across
-			// clients is not standardized, so we should not compare them.
-			if wantMap["error"] != nil && respMap["error"] != nil {
-				respMap["error"] = wantMap["error"]
+			if c.Type == "reth" {
+				// If errors exist in both, make them equal.
+				// While error comparison might be desirable, error text across
+				// clients is not standardized, so we should not compare them.
+				if wantMap["error"] != nil && respMap["error"] != nil {
+					respError := respMap["error"].(map[string]interface{})
+					wantError := wantMap["error"].(map[string]interface{})
+					respError["message"] = wantError["message"]
+					// cast back into the any type
+					respMap["error"] = respError
+				}
 			}
 
 			// Now compare.


### PR DESCRIPTION
Ignores any error difference between the client output and the expected result. This will ignore the error message and error code as long as they are included in both.