### PR TITLE
feat: ignore error codes in error expects

### DIFF
--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -143,6 +143,7 @@ func runTest(t *hivesim.T, c *hivesim.Client, data []byte) error {
 					respError := respMap["error"].(map[string]interface{})
 					wantError := wantMap["error"].(map[string]interface{})
 					respError["message"] = wantError["message"]
+					respError["code"] = wantError["code"]
 					// cast back into the any type
 					respMap["error"] = respError
 				}


### PR DESCRIPTION
Modified `rpc-compat` to ignore error codes when comparing error responses in invalid tests. `rpc-compat` will still ensure that the response from reth is an error in these tests.