### PR TITLE
fix: use proper bash existence check for auto-mine

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -131,7 +131,7 @@ fi
 #fi
 
 # If clique is expected enable auto-mine
-if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
+if [ -n "${HIVE_CLIQUE_PRIVATEKEY}" ] || [ -n "${HIVE_MINER}" ]; then
   FLAGS="$FLAGS --auto-mine"
 fi
 


### PR DESCRIPTION
Uses `-n` for `HIVE_MINER` and `HIVE_CLIQUE_PRIVATEKEY` for whether or not `--auto-mine` should be enabled.