### PR TITLE
fix: only run --auto-mine when clique requested

### DIFF
--- a/clients/reth/reth.sh
+++ b/clients/reth/reth.sh
@@ -130,7 +130,7 @@ fi
 #fi
 
 # If clique is expected enable auto-mine
-if [ -n "${HIVE_CLIQUE_PRIVATEKEY}" ] || [ -n "${HIVE_MINER}" ]; then
+if [ -n "${HIVE_CLIQUE_PRIVATEKEY}" ] || [ -n "${HIVE_CLIQUE_PERIOD}" ]; then
   FLAGS="$FLAGS --auto-mine"
 fi
 


### PR DESCRIPTION
I believe `HIVE_MINER` check is wrong

> - HIVE_MINER                address to credit with mining rewards

see this for example:

https://hivetests2.ethdevops.io/viewer.html?suiteid=1683065841-921749060b0141a4d882b90889732887.json&suitename=engine-api&testid=19&file=%2Fresults%2Fgo-ethereum%2Fclient-af198dc186a42f67b2701180b98f390c97d600a6052270e65a94111913dc6699.log

``` 
Running go-ethereum with flags --pcscdpath="" --verbosity=3 --bootnodes= --networkid 7 --syncmode full --mine --miner.threads 1 --miner.etherbase 658bdf435d810c91414ec09147daa6db62406379 --miner.gasprice 16000000000 --http --http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,eth,miner,net,personal,txpool,web3 --ws --ws.addr=0.0.0.0 --ws.origins "*" --ws.api=admin,debug,eth,miner,net,personal,txpool,web3 --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret /jwtsecret --nat=none
```

this caused panics in engine API hive tests, but reth entered auto-mine