### PR TITLE
Remove broad error checks and use upstream execution-apis

### DIFF
--- a/simulators/ethereum/rpc-compat/Dockerfile
+++ b/simulators/ethereum/rpc-compat/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1-alpine as builder
 RUN apk add --update git ca-certificates gcc musl-dev linux-headers
 
 # Clone the tests repo.
-RUN git clone --depth 1 https://github.com/paradigmxyz/execution-apis.git /execution-apis
+RUN git clone --depth 1 https://github.com/ethereum/execution-apis.git /execution-apis
 
 # To run local tests, copy the directory into the same as the simulator and
 # uncomment the line below

--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -123,35 +123,11 @@ func runTest(t *hivesim.T, c *hivesim.Client, data []byte) error {
 				return fmt.Errorf("invalid test, response before request")
 			}
 			want := []byte(strings.TrimSpace(line)[3:]) // trim leading "<< "
-
-			// Unmarshal to map[string]interface{} to compare.
-			var wantMap map[string]interface{}
-			if err := json.Unmarshal(want, &wantMap); err != nil {
-				return fmt.Errorf("failed to unmarshal value: %s\n", err)
-			}
-
-			var respMap map[string]interface{}
-			if err := json.Unmarshal(resp, &respMap); err != nil {
-				return fmt.Errorf("failed to unmarshal value: %s\n", err)
-			}
-
-			if c.Type == "reth" {
-				// If errors exist in both, make them equal.
-				// While error comparison might be desirable, error text across
-				// clients is not standardized, so we should not compare them.
-				if wantMap["error"] != nil && respMap["error"] != nil {
-					respError := respMap["error"].(map[string]interface{})
-					wantError := wantMap["error"].(map[string]interface{})
-					respError["message"] = wantError["message"]
-					respError["code"] = wantError["code"]
-					// cast back into the any type
-					respMap["error"] = respError
-				}
-			}
-
 			// Now compare.
-			d := diff.New().CompareObjects(respMap, wantMap)
-
+			d, err := diff.New().Compare(resp, want)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal value: %s\n", err)
+			}
 			// If there is a discrepancy, return error.
 			if d.Modified() {
 				var got map[string]interface{}


### PR DESCRIPTION
This is in preparation to upstream our hive additions - we don't need the upstream execution-apis any more, and the error assertions are not likely to be mergeable since they are reth specific. It's possible they could be merged separately though